### PR TITLE
Corrected the command for Grant permission on storage account

### DIFF
--- a/articles/backup/azure-kubernetes-service-cluster-manage-backups.md
+++ b/articles/backup/azure-kubernetes-service-cluster-manage-backups.md
@@ -120,7 +120,7 @@ To stop the Backup Extension install operation, use the following command:
 To provide *Storage Account Contributor Permission* to the Extension Identity on storage account, run the following command:
 
    ```azurecli-interactive
-   az role assignment create --assignee-object-id $(az k8s-extension show --name azure-aks-backup --cluster-name <aksclustername> --resource-group <aksclusterrg> --cluster-type managedClusters --query identity.principalId --output tsv) --role 'Storage Blob Data Contributor' --scope /subscriptions/<subscriptionid>/resourceGroups/<storageaccountrg>/providers/Microsoft.Storage/storageAccounts/<storageaccountname> 
+   az role assignment create --assignee-object-id $(az k8s-extension show --name azure-aks-backup --cluster-name <aksclustername> --resource-group <aksclusterrg> --cluster-type managedClusters --query aksAssignedIdentity.principalId --output tsv) --role 'Storage Blob Data Contributor' --scope /subscriptions/<subscriptionid>/resourceGroups/<storageaccountrg>/providers/Microsoft.Storage/storageAccounts/<storageaccountname> 
    ```
 
 


### PR DESCRIPTION
The correct command should be referencing aksAssignedIdentity.principalId and not identity.principalId

```
azadmin@jumpbox:~$ az k8s-extension show --name azure-aks-backup --cluster-name m1chianProdAks --resource-group m1chianProdRG --cluster-type managedClusters
{
  "aksAssignedIdentity": {
    "principalId": "cc413d45-b38b-46e5-8a0c-e9853825dd5a",
    "tenantId": null,
    "type": null
  },
  "autoUpgradeMinorVersion": true,
  "configurationProtectedSettings": {},
  "configurationSettings": {
    "configuration.backupStorageLocation.bucket": "prdaksbackup",
    "configuration.backupStorageLocation.config.resourceGroup": "prdaksbackuprg",
    "configuration.backupStorageLocation.config.storageAccount": "prdaksbackstore123",
    "configuration.backupStorageLocation.config.subscriptionId": "16eff991-0bd1-446c-9f6a-068ae9d333e3",
    "credentials.tenantId": "f5344ed6-25c0-4076-95fb-34828f0e2ef4"
  },
  "currentVersion": "0.0.2574-247",
  "customLocationSettings": null,
  "errorInfo": null,
  "extensionType": "microsoft.dataprotection.kubernetes",
  "id": "/subscriptions/16eff991-0bd1-446c-9f6a-068ae9d333e3/resourceGroups/m1chianProdRG/providers/Microsoft.ContainerService/managedClusters/m1chianProdAks/providers/Microsoft.KubernetesConfiguration/extensions/azure-aks-backup",
  "identity": null,
  "isSystemExtension": false,
  "name": "azure-aks-backup",
  "packageUri": null,
  "plan": null,
  "provisioningState": "Succeeded",
  "releaseTrain": "stable",
  "resourceGroup": "m1chianProdRG",
  "scope": {
    "cluster": {
      "releaseNamespace": "dataprotection-microsoft"
    },
    "namespace": null
  },
  "statuses": [],
  "systemData": {
    "createdAt": "2024-03-01T08:14:33.837512+00:00",
    "createdBy": null,
    "createdByType": null,
    "lastModifiedAt": "2024-03-01T08:14:33.837512+00:00",
    "lastModifiedBy": null,
    "lastModifiedByType": null
  },
  "type": "Microsoft.KubernetesConfiguration/extensions",
  "version": null
}
```


```
azadmin@jumpbox:~$ az k8s-extension show --name azure-aks-backup --cluster-name m1chianProdAks --resource-group m1chianProdRG --cluster-type managedClusters --query aksAssignedIdentity.principalId --output tsv
cc413d45-b38b-46e5-8a0c-e9853825dd5a
```
